### PR TITLE
Disable the addon in Fastboot

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@
 
 module.exports = {
   name: 'ember-cli-fastclick',
+
+  isEnabled: function() {
+    return !process.env.EMBER_CLI_FASTBOOT;
+  },
+
   included: function(app) {
     this._super.included(app);
     


### PR DESCRIPTION
Fastclick automatically touches 'navigator' for feature detection, which crashes fastboot because navigator doesn't exist in node