### PR TITLE
remove ember-try dependency which is now built into ember-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-suave": "2.0.1",
-    "ember-try": "~0.2.2",
     "loader.js": "^4.0.1"
   },
   "description": "Drop-in FastClick support for Ember CLI apps.",


### PR DESCRIPTION
ember-cli now has ember-try built in