### PR TITLE
wrap fastclick lib for FastBoot compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,10 @@
 var path = require('path');
 var broccoliFunnel = require('broccoli-funnel');
 var broccoliMergeTrees = require('broccoli-merge-trees');
+var map = require('broccoli-stew').map;
 
 module.exports = {
   name: 'ember-cli-fastclick',
-
-  isEnabled: function() {
-    return !process.env.EMBER_CLI_FASTBOOT;
-  },
 
   included: function(app) {
     this._super.included(app);
@@ -23,10 +20,12 @@ module.exports = {
       trees.push(vendorTree);
     }
     var libPath = path.dirname(require.resolve('fastclick'));
-    trees.push(new broccoliFunnel(libPath, {
+    var fastclickLib = new broccoliFunnel(libPath, {
       destDir: 'fastclick',
       include: ['*']
-    }));
+    });
+    fastclickLib = map(fastclickLib, content => `if (typeof FastBoot === 'undefined') { ${content} }`);
+    trees.push(fastclickLib);
     return broccoliMergeTrees(trees);
   }
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "broccoli-stew": "^1.5.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.5.0",
     "ember-cli-app-version": "^1.0.0",


### PR DESCRIPTION
just followed the directions here: https://gist.github.com/kratiahuja/d22de0fb1660cf0ef58f07a6bcbf1a1c#using-processenvember_cli_fastboot-to-run-import-in-browser-build