### PR TITLE
upgrade to babel@6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.5",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.3",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-qunit": "^1.4.1",
     "ember-cli-release": "1.0.0-beta.1",
@@ -51,7 +51,7 @@
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-stew": "^1.0.1",
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^6.3.0",
     "fastclick": "^1.0.6"
   },
   "ember-addon": {


### PR DESCRIPTION
Remove the Ember deprecation upgrading the babel version.

Fix #15